### PR TITLE
[RFT] Misc.  fixes

### DIFF
--- a/AutoWrapper/AutoWrapperMiddleware.cs
+++ b/AutoWrapper/AutoWrapperMiddleware.cs
@@ -10,7 +10,7 @@ namespace AutoWrapper
         private AutoWrapperMembers _awm;
         public AutoWrapperMiddleware(RequestDelegate next, AutoWrapperOptions options, ILogger<AutoWrapperMiddleware> logger) : base(next, options, logger)
         {
-            var jsonSettings = Helpers.JSONHelper.GetJSONSettings(options.IgnoreNullValue, options.UseCamelCaseNamingStrategy);
+            var jsonSettings = Helpers.JSONHelper.GetJSONSettings(options.IgnoreNullValue, options.ReferenceLoopHandling, options.UseCamelCaseNamingStrategy);
             _awm = new AutoWrapperMembers(options, logger, jsonSettings);
         }
 
@@ -25,7 +25,7 @@ namespace AutoWrapper
         private AutoWrapperMembers _awm;
         public AutoWrapperMiddleware(RequestDelegate next, AutoWrapperOptions options, ILogger<AutoWrapperMiddleware> logger) : base(next, options, logger)
         {
-            var tup = Helpers.JSONHelper.GetJSONSettings<T>(options.IgnoreNullValue, options.UseCamelCaseNamingStrategy);
+            var tup = Helpers.JSONHelper.GetJSONSettings<T>(options.IgnoreNullValue, options.ReferenceLoopHandling, options.UseCamelCaseNamingStrategy);
             _awm = new AutoWrapperMembers(options, logger, tup.Settings, tup.Mappings, true);
         }
 

--- a/AutoWrapper/AutoWrapperOptions.cs
+++ b/AutoWrapper/AutoWrapperOptions.cs
@@ -1,10 +1,12 @@
 ﻿using AutoWrapper.Base;
+using Newtonsoft.Json;
 
 namespace AutoWrapper
 {
     public class AutoWrapperOptions :OptionBase
     {
         public bool UseCustomSchema { get; set; } = false;
+        public ReferenceLoopHandling ReferenceLoopHandling { get; set; } = ReferenceLoopHandling.Ignore;
     }
 
     public class AutoWrapperOptions<T> :OptionBase

--- a/AutoWrapper/Base/OptionBase.cs
+++ b/AutoWrapper/Base/OptionBase.cs
@@ -26,6 +26,11 @@
         public bool IsApiOnly { get; set; } = true;
 
         /// <summary>
+        /// This will ignore validation that insures string does not contain HTML
+        /// </summary>
+        public bool BypassHTMLValidation { get; set; } = false;
+
+        /// <summary>
         /// Set the Api path segment to validate. The default value is '/api'. Only works if IsApiOnly is set to false.
         /// </summary>
         public string WrapWhenApiPathStartsWith { get; set; } = "/api";

--- a/AutoWrapper/Base/WrapperBase.cs
+++ b/AutoWrapper/Base/WrapperBase.cs
@@ -54,7 +54,7 @@ namespace AutoWrapper.Base
                         if (context.Response.StatusCode != Status304NotModified)
                         {
 
-                            if (!_options.IsApiOnly && bodyAsText.IsHtml() && context.Response.StatusCode == Status200OK)
+                            if (!_options.IsApiOnly && (bodyAsText.IsHtml() && !_options.BypassHTMLValidation) && context.Response.StatusCode == Status200OK)
                                 context.Response.StatusCode = Status404NotFound;
 
                             if (!context.Request.Path.StartsWithSegments(new PathString(_options.WrapWhenApiPathStartsWith))

--- a/AutoWrapper/Helpers/JsonHelper.cs
+++ b/AutoWrapper/Helpers/JsonHelper.cs
@@ -7,14 +7,14 @@ namespace AutoWrapper.Helpers
 {
     internal static class JSONHelper
     {
-        public static JsonSerializerSettings GetJSONSettings(bool ignoreNull = true, bool useCamelCaseNaming = true)
+        public static JsonSerializerSettings GetJSONSettings(bool ignoreNull = true, ReferenceLoopHandling referenceLoopHandling = ReferenceLoopHandling.Ignore, bool useCamelCaseNaming = true)
         {
-            return new CamelCaseContractResolverJsonSettings().GetJSONSettings(ignoreNull, useCamelCaseNaming);
+            return new CamelCaseContractResolverJsonSettings().GetJSONSettings(ignoreNull, referenceLoopHandling, useCamelCaseNaming);
         }
 
-        public static (JsonSerializerSettings Settings, Dictionary<string, string> Mappings) GetJSONSettings<T>(bool ignoreNull = true, bool useCamelCaseNaming = true)
+        public static (JsonSerializerSettings Settings, Dictionary<string, string> Mappings) GetJSONSettings<T>(bool ignoreNull = true, ReferenceLoopHandling referenceLoopHandling = ReferenceLoopHandling.Ignore, bool useCamelCaseNaming = true)
         {
-            return new CustomContractResolverJsonSettings<T>().GetJSONSettings(ignoreNull, useCamelCaseNaming);
+            return new CustomContractResolverJsonSettings<T>().GetJSONSettings(ignoreNull, referenceLoopHandling, useCamelCaseNaming);
         }
 
         public static bool HasProperty(dynamic obj, string name)

--- a/AutoWrapper/Helpers/JsonSettings.cs
+++ b/AutoWrapper/Helpers/JsonSettings.cs
@@ -9,20 +9,21 @@ namespace AutoWrapper.Helpers
 {
     internal class CamelCaseContractResolverJsonSettings
     {
-        public JsonSerializerSettings GetJSONSettings(bool ignoreNull, bool useCamelCaseNaming = true)
+        public JsonSerializerSettings GetJSONSettings(bool ignoreNull, ReferenceLoopHandling referenceLoopHandling = ReferenceLoopHandling.Ignore, bool useCamelCaseNaming = true)
         {
             return new JsonSerializerSettings
             {
                 ContractResolver = useCamelCaseNaming ? new CamelCasePropertyNamesContractResolver() :  new DefaultContractResolver(),
                 Converters = new List<JsonConverter> { new StringEnumConverter() },
-                NullValueHandling = ignoreNull ? NullValueHandling.Ignore : NullValueHandling.Include
+                NullValueHandling = ignoreNull ? NullValueHandling.Ignore : NullValueHandling.Include,
+                ReferenceLoopHandling = referenceLoopHandling
             };
         }
     }
 
     internal class CustomContractResolverJsonSettings<T>
     {
-        public (JsonSerializerSettings Settings, Dictionary<string, string> Mappings) GetJSONSettings(bool ignoreNull, bool useCamelCaseNaming = true)
+        public (JsonSerializerSettings Settings, Dictionary<string, string> Mappings) GetJSONSettings(bool ignoreNull, ReferenceLoopHandling referenceLoopHandling = ReferenceLoopHandling.Ignore, bool useCamelCaseNaming = true)
         {
             var resolver = new CustomContractResolver<T>(useCamelCaseNaming);
             var propMappings = resolver._propertyMappings;
@@ -30,7 +31,8 @@ namespace AutoWrapper.Helpers
             var settings = new JsonSerializerSettings
             {
                 ContractResolver = resolver,
-                NullValueHandling = ignoreNull ? NullValueHandling.Ignore : NullValueHandling.Include
+                NullValueHandling = ignoreNull ? NullValueHandling.Ignore : NullValueHandling.Include,
+                ReferenceLoopHandling = referenceLoopHandling
             };
 
             return (settings, propMappings);


### PR DESCRIPTION
Added:
Reference Loop Handling option
Added BypassHTMLValidation option

Both of these address issues faced during roll out of recent app using AutoWrapper. The first was the issue with a self referencing loop caused by Entity Framework. The second was caused by valid JSON containing HTML (this is a psudo CMS we are writing).