### PR TITLE
[FIX] Simplify AutoWrapper attributes and use endpoint metadata instead

### DIFF
--- a/src/AutoWrapper/Base/WrapperBase.cs
+++ b/src/AutoWrapper/Base/WrapperBase.cs
@@ -130,7 +130,7 @@ namespace AutoWrapper.Base
             if (_options.ShouldLogRequestData)
             {
                 var endpoint = context.GetEndpoint();
-                return (endpoint?.Metadata?.GetMetadata<RequestDataLogIgnore>() is object);
+                return (endpoint?.Metadata?.GetMetadata<RequestDataLogIgnoreAttribute>() is object);
             }
 
             return false;

--- a/src/AutoWrapper/Base/WrapperBase.cs
+++ b/src/AutoWrapper/Base/WrapperBase.cs
@@ -8,6 +8,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using AutoWrapper.Filters;
 using static Microsoft.AspNetCore.Http.StatusCodes;
 
 namespace AutoWrapper.Base
@@ -49,9 +50,9 @@ namespace AutoWrapper.Base
 
                     if (context.Response.HasStarted) { LogResponseHasStartedError(); return; }
 
-                    var actionIgnore = context.Request.Headers[TypeIdentifier.AutoWrapIgnoreFilterHeader];
-                    if (actionIgnore.Count > 0) 
-                    { 
+                    var endpoint = context.GetEndpoint();
+                    if (endpoint?.Metadata?.GetMetadata<AutoWrapIgnoreAttribute>() is object)
+                    {
                         await awm.RevertResponseBodyStreamAsync(memoryStream, originalResponseBodyStream);
                         return;
                     }
@@ -128,9 +129,8 @@ namespace AutoWrapper.Base
         {
             if (_options.ShouldLogRequestData)
             {
-                return context.Request.Headers[TypeIdentifier.ShouldLogRequestDataFilterHeader].Count > 0
-                            ? context.Response.Headers[TypeIdentifier.ShouldLogRequestDataFilterHeader].ToString().ToBoolean()
-                            : true;
+                var endpoint = context.GetEndpoint();
+                return (endpoint?.Metadata?.GetMetadata<RequestDataLogIgnore>() is object);
             }
 
             return false;

--- a/src/AutoWrapper/Filters/AutoWrapIgnore.cs
+++ b/src/AutoWrapper/Filters/AutoWrapIgnore.cs
@@ -1,26 +1,11 @@
-﻿using AutoWrapper.Helpers;
-using Microsoft.AspNetCore.Mvc.Filters;
-using System;
+﻿using System;
 
 namespace AutoWrapper.Filters
 {
-    public class AutoWrapIgnore : Attribute, IActionFilter
+    public class AutoWrapIgnoreAttribute : Attribute
     {
         public bool ShouldLogRequestData{ get; set; } = true;
-        public AutoWrapIgnore(){}
-        public void OnActionExecuting(ActionExecutingContext context)
-        {
-            context.HttpContext.Request.Headers.Add(TypeIdentifier.AutoWrapIgnoreFilterHeader, new string[] { "true" });
 
-            if (!ShouldLogRequestData)
-            {
-                context.HttpContext.Request.Headers.Add(TypeIdentifier.ShouldLogRequestDataFilterHeader, new string[] { "false" });
-            }
-        }
-
-        public void OnActionExecuted(ActionExecutedContext context)
-        {
-            // our code after action executes
-        }
+        public AutoWrapIgnoreAttribute(){}
     }
 }

--- a/src/AutoWrapper/Filters/RequestDataLogIgnore.cs
+++ b/src/AutoWrapper/Filters/RequestDataLogIgnore.cs
@@ -2,7 +2,7 @@
 
 namespace AutoWrapper.Filters
 {
-    public class RequestDataLogIgnore: Attribute
+    public class RequestDataLogIgnoreAttribute: Attribute
     {
     }
 }

--- a/src/AutoWrapper/Filters/RequestDataLogIgnore.cs
+++ b/src/AutoWrapper/Filters/RequestDataLogIgnore.cs
@@ -1,19 +1,8 @@
-﻿using AutoWrapper.Helpers;
-using Microsoft.AspNetCore.Mvc.Filters;
-using System;
+﻿using System;
 
 namespace AutoWrapper.Filters
 {
-    public class RequestDataLogIgnore: Attribute, IActionFilter
+    public class RequestDataLogIgnore: Attribute
     {
-        public void OnActionExecuting(ActionExecutingContext context)
-        {
-            context.HttpContext.Request.Headers.Add(TypeIdentifier.ShouldLogRequestDataFilterHeader, new string[] { "false" });
-        }
-
-        public void OnActionExecuted(ActionExecutedContext context)
-        {
-            // our code after action executes
-        }
     }
 }

--- a/src/AutoWrapper/Helpers/TypeIdentifier.cs
+++ b/src/AutoWrapper/Helpers/TypeIdentifier.cs
@@ -5,7 +5,5 @@
         internal const string JSONHttpContentMediaType = "application/json";
         internal const string ProblemJSONHttpContentMediaType = "application/problem+json";
         internal const string ProblemXMLHttpContentMediaType = "application/problem+xml";
-        internal const string AutoWrapIgnoreFilterHeader = "AutoWrapIgnoreFilter";
-        internal const string ShouldLogRequestDataFilterHeader = "ShouldLogRequestDataFilterHeader";
     }
 }


### PR DESCRIPTION
[FIX] Simplify AutoWrapper attributes by eliminating unneeded IActionFilter and request headers. Instead reference the metadata from the endpoints themselves.

This helps solve this issue:
https://github.com/proudmonkey/AutoWrapper/issues/88