### PR TITLE
Fix inconsistencies in wrapping responses

### DIFF
--- a/src/.contextkeeper/.git-branches/v5-beta.ck
+++ b/src/.contextkeeper/.git-branches/v5-beta.ck
@@ -1,0 +1,74 @@
+{
+  "ContextKeeper": "0.8",
+  "State": [
+    {
+      "WindowType": "MainWindow",
+      "Window": {
+        "Left": 46,
+        "Top": 0,
+        "Width": 2244,
+        "Height": 1394
+      },
+      "Docks": [
+        {
+          "Documents": [
+            {
+              "FilePath": "A:\\Users\\aalbert\\Code\\TIPCGitHub\\AutoWrapper\\src\\AutoWrapper\\Handlers\\ApiRequestHandlerMember.cs",
+              "FullName": "ApiRequestHandlerMember.cs",
+              "DockedHeight": {
+                "UnitType": "Stretch",
+                "Value": 200.0
+              },
+              "DockedWidth": {
+                "UnitType": "Stretch",
+                "Value": 200.0
+              },
+              "Line": 145,
+              "Column": 86,
+              "IsPinned": false
+            },
+            {
+              "FilePath": "A:\\Users\\aalbert\\Code\\TIPCGitHub\\AutoWrapper\\src\\AutoWrapper\\Models\\ApiResponse.cs",
+              "FullName": "ApiResponse.cs",
+              "DockedHeight": {
+                "UnitType": "Stretch",
+                "Value": 200.0
+              },
+              "DockedWidth": {
+                "UnitType": "Stretch",
+                "Value": 200.0
+              },
+              "Line": 19,
+              "Column": 9,
+              "IsPinned": false
+            },
+            {
+              "FilePath": "A:\\Users\\aalbert\\Code\\TIPCGitHub\\AutoWrapper\\src\\AutoWrapper\\Handlers\\ApiProblemDetailsHandler.cs",
+              "FullName": "ApiProblemDetailsHandler.cs",
+              "DockedHeight": {
+                "UnitType": "Stretch",
+                "Value": 200.0
+              },
+              "DockedWidth": {
+                "UnitType": "Stretch",
+                "Value": 200.0
+              },
+              "Line": 1,
+              "Column": 1,
+              "IsPinned": false
+            }
+          ],
+          "DockedHeight": {
+            "UnitType": "Stretch",
+            "Value": 200.0
+          },
+          "DockedWidth": {
+            "UnitType": "Stretch",
+            "Value": 200.0
+          }
+        }
+      ],
+      "Orientation": "Horizontal"
+    }
+  ]
+}

--- a/src/AutoWrapper/Constants/ResponseMessage.cs
+++ b/src/AutoWrapper/Constants/ResponseMessage.cs
@@ -7,6 +7,7 @@
         internal const string BadRequest = "Request invalid.";
         internal const string MethodNotAllowed = "Request responded with 'Method Not Allowed'.";
         internal const string NoContent = "Request no content. The specified uri does not contain any content.";
+        internal const string NotImplemented = "Request endpoint not implemented.  The specified uri exists but is not currently implemented.";
         internal const string Exception = "Request responded with exceptions.";
         internal const string UnAuthorized = "Request denied. Unauthorized access.";
         internal const string ValidationError = "Request responded with one or more validation errors.";

--- a/src/AutoWrapper/Handlers/ApiRequestHandlerMember.cs
+++ b/src/AutoWrapper/Handlers/ApiRequestHandlerMember.cs
@@ -155,7 +155,10 @@
         {
             var result = content.ToString() ?? string.Empty;
             var statusCode = (!_options.ShowStatusCode) ? null : (int?)httpStatusCode;
-            var apiResponse = new ApiResponse($"{httpMethod} {ResponseMessage.Success}", content, statusCode);
+            var apiResponse = new ApiResponse($"{httpMethod} {ResponseMessage.Success}", content, statusCode)
+            {
+                IsError = _options.ShowIsErrorFlagForSuccessfulResponse ? false : null
+            };
 
             var serialized = JsonSerializer.Serialize(apiResponse, _jsonOptions!);
 

--- a/src/AutoWrapper/Models/ResponseTypes/ApiProblemDetailsExceptionResponse.cs
+++ b/src/AutoWrapper/Models/ResponseTypes/ApiProblemDetailsExceptionResponse.cs
@@ -2,9 +2,10 @@
 
 namespace AutoWrapper.Models.ResponseTypes
 {
-    public class ApiProblemDetailsExceptionResponse: ProblemDetails
+    public class ApiProblemDetailsExceptionResponse : ProblemDetails
     {
         public bool IsError { get; set; }
+        public string? ErrorID { get; set; }
         public ErrorDetails? Errors { get; set; }
         public class ErrorDetails
         {

--- a/src/AutoWrapper/Models/ResponseTypes/ApiProblemDetailsResponse.cs
+++ b/src/AutoWrapper/Models/ResponseTypes/ApiProblemDetailsResponse.cs
@@ -5,5 +5,7 @@ namespace AutoWrapper.Models.ResponseTypes
     public class ApiProblemDetailsResponse : ProblemDetails
     {
         public bool IsError { get; set; }
+        public string? ErrorID { get; set; }
+
     }
 }

--- a/src/AutoWrapper/Models/ResponseTypes/ApiProblemDetailsResponse.cs
+++ b/src/AutoWrapper/Models/ResponseTypes/ApiProblemDetailsResponse.cs
@@ -2,7 +2,7 @@
 
 namespace AutoWrapper.Models.ResponseTypes
 {
-    public class ApiProblemDetailsResponse: ProblemDetails
+    public class ApiProblemDetailsResponse : ProblemDetails
     {
         public bool IsError { get; set; }
     }

--- a/src/AutoWrapper/Models/ResponseTypes/ApiProblemDetailsValidationErrorResponse.cs
+++ b/src/AutoWrapper/Models/ResponseTypes/ApiProblemDetailsValidationErrorResponse.cs
@@ -3,9 +3,11 @@
     using Microsoft.AspNetCore.Mvc;
     using System.Collections.Generic;
 
-    public class ApiProblemDetailsValidationErrorResponse: ProblemDetails
+    public class ApiProblemDetailsValidationErrorResponse : ProblemDetails
     {
         public bool IsError { get; set; }
+        public string? ErrorID { get; set; }
+
         public IEnumerable<ValidationError>? ValidationErrors { get; set; }
     }
 }

--- a/src/AutoWrapper/Models/ResponseTypes/ApiResultResponse.cs
+++ b/src/AutoWrapper/Models/ResponseTypes/ApiResultResponse.cs
@@ -1,8 +1,14 @@
 ﻿namespace AutoWrapper.Models.ResponseTypes
 {
-    public class ApiResultResponse<T> where T : class
+    public class ApiResultResponse<T> : ApiResultResponse
     {
-        public string Message { get; set; } = null!;
-        public T Result { get; set; } = null!;
+        public T Result { get; set; } = default;
+    }
+
+    public class ApiResultResponse
+    {
+        public bool IsError { get; set; }
+        public int Status { get; set; }
+        public string? Message { get; set; } = null!;
     }
 }


### PR DESCRIPTION
Some exceptions have special casing for http status codes, however the codes were not being set consistently.  `AutoWrapperBase` has a branch on `DisableProblemDetailsException`. If true, certain exceptions would get special status codes (ex `UnauthorizedAccessException=401`) on the response.  If false, the status modifier was skipped and responses were sent with a basic 500 code.  

This has been resolved.  In the future, the logic should be extracted so response codes are guaranteed to be sync'd for `ApiProblemDetailsHandler.HandleProblemDetailsAsync` and `ApiRequestHandler.HandleExceptionAsync`

Also added a special exception case `NotImplementedException=501`.  This is helpful for auto-scaffolded APIs

Also fixed a bug that made `ShowIsErrorFlagForSuccessfulResponse=true` a NOP