### PR TITLE
[FIX] Update StringExtension method to vaidate JSON before parsing

### DIFF
--- a/src/AutoWrapper/Extensions/StringExtension.cs
+++ b/src/AutoWrapper/Extensions/StringExtension.cs
@@ -29,11 +29,7 @@ namespace AutoWrapper.Extensions
 
         public static (bool IsEncoded, string ParsedText) VerifyBodyContent(this string text)
         {
-            if(string.IsNullOrWhiteSpace(text)) 
-            {
-                return (false, text);
-            }
-            if(!text.StartsWith("{") && !text.StartsWith("["))
+            if(!IsValidJsonText(text)) 
             {
                 return (false, text);
             }
@@ -63,6 +59,18 @@ namespace AutoWrapper.Extensions
                 return Char.ToLowerInvariant(str[0]) + str.Substring(1);
             }
             return str;
+        }
+
+        private static bool IsValidJsonText(string text)
+        {
+            if(string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+            bool startsWithBrace = text.StartsWith("{") && text.EndsWith("}");
+            bool startsWithBracket = text.StartsWith("[") && text.EndsWith("]");
+            
+            return startsWithBrace || startsWithBracket;
         }
         
     }

--- a/src/AutoWrapper/Extensions/StringExtension.cs
+++ b/src/AutoWrapper/Extensions/StringExtension.cs
@@ -29,6 +29,14 @@ namespace AutoWrapper.Extensions
 
         public static (bool IsEncoded, string ParsedText) VerifyBodyContent(this string text)
         {
+            if(string.IsNullOrWhiteSpace(text)) 
+            {
+                return (false, text);
+            }
+            if(!text.StartsWith("{") && !text.StartsWith("["))
+            {
+                return (false, text);
+            }
             try
             {
                 var obj = JToken.Parse(text);


### PR DESCRIPTION
Refactor of **VerifyBodyContent** Method in **StringExtension**:

Added validation to the VerifyBodyContent method to check the input string for valid JSON format before attempting to parse it. Previously, if the input was an empty string or invalid JSON, it would throw an exception, triggering the catch block. While the exception was handled, the **unnecessary overhead of a try-catch block**—particularly for scenarios where the input is clearly invalid—was avoided by performing the validation upfront. This improves performance by reducing unnecessary exception handling overhead, which can be costly.